### PR TITLE
[HEAP-25319] Huseyin hex update

### DIFF
--- a/bin/generateTestHeapHeaders.js
+++ b/bin/generateTestHeapHeaders.js
@@ -68,7 +68,7 @@ if (argv.type === 'sync') {
     dataBody = (JSON.stringify(drainData));
 }
 
-const hmac = CryptoJS.enc.Base64.stringify(
+const hmac = CryptoJS.enc.Hex.stringify(
     CryptoJS.HmacSHA256(
         `${timeStamp}${dataBody}`,
         secretKey

--- a/middleware/validateHeapHeader.ts
+++ b/middleware/validateHeapHeader.ts
@@ -58,7 +58,7 @@ export const validateHeapHeader = async (ctx: Context, next: () => Promise<any>)
         `${heapMap.get("ts")}${JSON.stringify(ctx.request.body)}`,
         process.env.SECRET_KEY
     );
-    const computedHmac = CryptoJS.enc.Base64.stringify(hmac)
+    const computedHmac = CryptoJS.enc.Hex.stringify(hmac)
     const receivedHmac = heapMap.get("hmac")
     if (computedHmac !== receivedHmac) {
         ctx.throw(403, `Invalid hmac. Recieved: ${receivedHmac}, Computed: ${computedHmac}`);

--- a/middleware/validateHeapHeader.ts
+++ b/middleware/validateHeapHeader.ts
@@ -58,8 +58,8 @@ export const validateHeapHeader = async (ctx: Context, next: () => Promise<any>)
         `${heapMap.get("ts")}${JSON.stringify(ctx.request.body)}`,
         process.env.SECRET_KEY
     );
-    const computedHmac = CryptoJS.enc.Hex.stringify(hmac)
-    const receivedHmac = heapMap.get("hmac")
+    const computedHmac = CryptoJS.enc.Hex.stringify(hmac).toLowerCase();
+    const receivedHmac = heapMap.get("hmac").toLowerCase();
     if (computedHmac !== receivedHmac) {
         ctx.throw(403, `Invalid hmac. Recieved: ${receivedHmac}, Computed: ${computedHmac}`);
     }


### PR DESCRIPTION
This pr use base16 instead of base64 for hmac encoding.

```
heap-partner-api-reference on  huseyin-hex-update [!+?] is 📦 v1.0.0 via  v12.21.0 on ☁️  (us-east-1)
❯ node bin/generateTestHeapHeaders.js  -t "sync" -u "http://localhost:3000/users_sync"| sh
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 3000 (#0)
> POST /users_sync HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.64.1
> Accept: */*
> Content-Type: application/json
> Heap-Hash: ts:1633640694924,hmac:16e3fc216a9f85d85db29fe598e7b595e5193be2e37cb40eaa0cdd7ddcca6037
> Content-Length: 441
>
* upload completely sent off: 441 out of 441 bytes
< HTTP/1.1 200 OK
< Content-Type: text/plain; charset=utf-8
< Content-Length: 2
< Date: Thu, 07 Oct 2021 21:04:54 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
<
* Connection #0 to host localhost left intact
OK* Closing connection 0

heap-partner-api-reference on  huseyin-hex-update [!+?] is 📦 v1.0.0 via  v12.21.0 on ☁️  (us-east-1)
❯
```

I also tested this with dataout integration tests and it was working as expected: 
```
❯ npm run build ; npm run start

> heap@1.0.0 build /Users/huseyinyilmaz/heap/heap-partner-api-reference
> tsc
> heap@1.0.0 start /Users/huseyinyilmaz/heap/heap-partner-api-reference
> node dist/app.js
  <-- POST /users_sync
Syncing page 1 of 1
        for sync task
Adding email user1 for segment symbol:4
Adding email user2 for segment symbol:4
  --> POST /users_sync 200 30ms -
  <-- POST /users_sync
Syncing page 1 of 1
        for sync task
Removing email user1 for segment symbol:4
Removing email user2 for segment symbol:4
  --> POST /users_sync 200 3ms -
  <-- POST /users_sync
  xxx POST /users_sync 403 2ms -
ForbiddenError: Invalid hmac. Recieved: ccb28fc0e400df51f4ce89a01131c8858e0e60a2ac0ae2cdd2ea7328a0b67bbf, Computed: 9de4560def63e61a37b8c00a52d489ad528b4b87297ef588377b129515a84d83
    at Object.throw (/Users/huseyinyilmaz/heap/heap-partner-api-reference/node_modules/koa/lib/context.js:97:11)
    at /Users/huseyinyilmaz/heap/heap-partner-api-reference/dist/middleware/validateHeapHeader.js:111:30
    at step (/Users/huseyinyilmaz/heap/heap-partner-api-reference/dist/middleware/validateHeapHeader.js:52:23)
    at Object.next (/Users/huseyinyilmaz/heap/heap-partner-api-reference/dist/middleware/validateHeapHeader.js:33:53)
    at /Users/huseyinyilmaz/heap/heap-partner-api-reference/dist/middleware/validateHeapHeader.js:27:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/huseyinyilmaz/heap/heap-partner-api-reference/dist/middleware/validateHeapHeader.js:23:12)
    at validateHeapHeader (/Users/huseyinyilmaz/heap/heap-partner-api-reference/dist/middleware/validateHeapHeader.js:91:56)
    at dispatch (/Users/huseyinyilmaz/heap/heap-partner-api-reference/node_modules/koa-compose/index.js:42:32)
    at bodyParser (/Users/huseyinyilmaz/heap/heap-partner-api-reference/node_modules/koa-bodyparser/index.js:95:11)
```